### PR TITLE
Autoload v composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
             "role": "Developers"
         }
     ],
+    "autoload": {
+        "files": ["SFAPIclient/SFAPIclient.php"]  
+    },
     "require": {
         "php": ">=5.3.0"
     }


### PR DESCRIPTION
Aktuálne nie je v composer.json žiadny autoload. Takže aj keď sa tento balík nainštaluje cez composer, musí sa robiť ručne require. Táto zmena spôsobí, že bude stačiť rovno použiť \SFAPIclient().